### PR TITLE
fix(post): Fix edit post has bug when upload new images

### DIFF
--- a/core/network/posts/forms.py
+++ b/core/network/posts/forms.py
@@ -81,7 +81,7 @@ class PostForm(forms.ModelForm):
             )
 
     def _get_max_order(self, post):
-        return post.medias.aggregate(max_order=Max("order"))["max_order"]
+        return post.medias.aggregate(max_order=Max("order"))["max_order"] or 0
 
     def clean(self):
         """Validate allowed media amount."""

--- a/core/network/posts/views.py
+++ b/core/network/posts/views.py
@@ -12,7 +12,6 @@ from .models import Post, PostMedia
 # Create your views here.
 
 
-# TODO allow user to click avatar picture and get directed to their profile page
 # TODO allow like/unlike the post
 class PostListView(ListView):
     """Post List View."""
@@ -44,7 +43,6 @@ class PostCreateView(LoginRequiredMixin, CreateView):
         return super().form_valid(form)
 
 
-# TODO add permissions later
 class PostEditView(LoginRequiredMixin, UpdateView):
     """Post update view."""
 
@@ -67,6 +65,7 @@ class PostEditView(LoginRequiredMixin, UpdateView):
         return super().form_valid(form)
 
 
+# TODO return to the last stay page after deletion
 class PostDeleteView(DeleteView):
     """Post Delete View."""
 


### PR DESCRIPTION
The bug happens when assigning order, because _get_max_order return None if the old post has no medias, None cannot be added by 1