### PR TITLE
fix(egg): Fix egg state is reflect on other user's nest page

### DIFF
--- a/core/network/posts/views.py
+++ b/core/network/posts/views.py
@@ -220,8 +220,9 @@ class IncubatingEggView(LoginRequiredMixin, View):
 
     def get(self, request, **kwargs):
         """Return incubating egg template."""
-        post_id = IncubationService.get_incubating_post_id(request.user.id)
-        egg_url = IncubationService.get_incubating_egg_url(request.user.id)
+        user_id = request.GET.get("user_id", request.user.id)
+        post_id = IncubationService.get_incubating_post_id(user_id)
+        egg_url = IncubationService.get_incubating_egg_url(user_id)
         egg_type = EggManageService.get_egg_type(egg_url)
         if post_id:
             return render(

--- a/core/network/templates/network/layout.html
+++ b/core/network/templates/network/layout.html
@@ -64,7 +64,12 @@
         },
         {# Egg Management #}
         hatchedPostId: $persist(null),
-        eggHatched: $persist(false),
+        {% if profile.user == request.user %}
+          {# persist eggHatched state user's own page #}
+         eggHatched: $persist(false),
+        {% else %}
+          eggHatched: false,
+        {% endif %}
         isHatching: false, {# Control egg hatching effect showing #}
 
         {# Alert Management#}

--- a/core/network/templates/posts/partial/incubating_egg.html
+++ b/core/network/templates/posts/partial/incubating_egg.html
@@ -32,8 +32,6 @@
       isIncubating = false;
     },
     hatchingEnd() {
-
-     
       $dispatch('post-hatched'); 
 
       isHatching = false;

--- a/core/network/templates/posts/partial/turboy.html
+++ b/core/network/templates/posts/partial/turboy.html
@@ -38,6 +38,7 @@
                 <div 
                   id="incubating-egg-container"
                   hx-get="{% url 'egg' %}"
+                  hx-vals='{ "user_id": "{{ user.id }}" }'
                   hx-trigger="egg-fetch-ready"
                   hx-swap="innerHTML"
                   x-ref="eggDiv"

--- a/core/network/templates/profiles/tabs/partial/nest.html
+++ b/core/network/templates/profiles/tabs/partial/nest.html
@@ -34,8 +34,8 @@
       x-data="{ 
         onListPage: false,
         displayScreen: false,
-      }">
-    
+      }"
+      >
         <!-- Nest Title -->
         <div class="text-center mb-6">
           <div class="flex items-center justify-center mb-2">
@@ -87,6 +87,7 @@
                       x-effect="if(isIncubating) { $nextTick(() => $dispatch('egg-fetch-ready')) }"
                       x-init="htmx.process($el)"
                       hx-get="{% url 'egg' %}"
+                      hx-vals='{"user_id": "{{ profile.user.id }}"}'
                       hx-trigger="egg-fetch-ready"
                       hx-target="#egg-nest"
                       hx-swap="innerHTML"
@@ -161,9 +162,7 @@
           
           <a 
             :href="`{% url 'index' %}#${hatchedPostId}`"
-            {% if profile.user == request.user %}
-              @click="$nextTick(() => {eggHatched = false; hatchedPostId = null})"
-            {% endif %}
+            @click="$nextTick(() => {eggHatched = false; hatchedPostId = null;})"
             class="pixel-btn flex justify-center items-center text-white font-bold py-3 px-6 
                     no-underline transform hover:scale-105 transition-all duration-300"
             style="text-decoration: none; font-family: 'Press Start 2P', monospace; font-size: 10px;"


### PR DESCRIPTION
1. Egg is showing in other user's page when is incubating 
2. Egg hatched congrats will not persist on other user's nest after refresh